### PR TITLE
Updated TypeScript typings to indicate 'params' argument is optional.

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -54,7 +54,7 @@ export declare class Ease extends EventEmitter
     destroy(): void
     add(element: PIXI.DisplayObject, params: EaseParams, options: AddOptions): Easing
     removeAllEases(element: PIXI.DisplayObject): void
-    removeEase(element: PIXI.DisplayObject, param: string | string[]): void
+    removeEase(element: PIXI.DisplayObject, param?: string | string[]): void
     removeAll(force: boolean): void
     update(elapsed?: number): void
     countElements(): number
@@ -78,7 +78,7 @@ export declare class Easing extends EventEmitter
     constructor(element: EaseDisplayObject | EaseDisplayObject[], params: EaseParams, options: EaseOptions)
 
     addParam(element: EaseDisplayObject, entry: string, param: any): void
-    remove(element: EaseDisplayObject, params: string | string[]): void
+    remove(element: EaseDisplayObject, params?: string | string[]): void
 
     update(elasped: number): void
     count(): number

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pixi-ease",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "description": "an animation library using easing functions",
     "types": "@types/index.d.ts",
     "main": "dist/ease.js",

--- a/src/easing.js
+++ b/src/easing.js
@@ -146,11 +146,14 @@ export class Easing extends Events
         }
         else
         {
-            params = typeof params === 'undefined' ? false : typeof params === 'string' ? [params] : params
+            if (typeof params === 'string')
+            {
+                params = [params]
+            }
             for (let i = 0; i < this.eases.length; i++)
             {
                 const ease = this.eases[i]
-                if ((!element || ease.element === element) && (params === false || params.indexOf(ease.entry) !== -1))
+                if ((!element || ease.element === element) && (!params || params.indexOf(ease.entry) !== -1))
                 {
                     this.eases.splice(i, 1)
                     i--


### PR DESCRIPTION
It appears that the `remove()` and `removeEase()` methods allow the second argument, `param`/`params` to be optional (`undefined`) but the TS typings don't allow this. I made this second argument optional in the typings file and simplified the logic a bit.