### PR TITLE
Fixed wait property

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'eventemitter3'
 
 interface EaseOptions {
     duration?: number
+    wait?: number
     ease?: string | Function
     useRaf?: boolean
     ticker?: PIXI.Ticker

--- a/src/ease.js
+++ b/src/ease.js
@@ -5,6 +5,7 @@ import { Easing } from './easing'
 
 const easeOptions = {
     duration: 1000,
+    wait: 0,
     ease: Penner.easeInOutSine,
     maxFrame: 1000 / 60,
     ticker: null,


### PR DESCRIPTION
The missing "wait" property has been added to the options. The linter indicated that it was not possible to include the "wait" property in the constructor call for Ease